### PR TITLE
try to load config from ~/pelias.json when PELIAS_CONFIG not set

### DIFF
--- a/config/local.json
+++ b/config/local.json
@@ -1,0 +1,20 @@
+{
+  "imports": {
+    "geonames": {
+      "datapath": "/media/hdd",
+      "import": [
+        { "type": "geoname", "filename": "GB.zip" }
+      ]
+    },
+    "quattroshapes": {
+      "datapath": "/media/hdd/simplified"
+    },
+    "openstreetmap": {
+      "datapath": "/media/hdd/osm/mapzen-metro",
+      "import": [{
+        "type": { "node": "osmnode", "way": "osmway" },
+        "filename": "london.osm.pbf"
+      }]
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
 
-var Mergeable = require('mergeable');
-var defaults = new Mergeable( __dirname + '/config/defaults.json' );
+var fs = require('fs'),
+    Mergeable = require('mergeable'),
+    defaults = new Mergeable( __dirname + '/config/defaults.json' ),
+    localpath = '~/pelias.json';
 
 // allow the ops guys to override settings on the server
 var generate = function( deep ){
+
+  // load config from ENV
   if( process.env.hasOwnProperty('PELIAS_CONFIG') ){
     var production = new Mergeable( defaults.export() );
     var path = process.env['PELIAS_CONFIG'];
@@ -11,12 +15,23 @@ var generate = function( deep ){
     else { production.shallowMergeFromPath( path ); }
     return production;
   }
+
+  // load config from local file
+  else if( fs.existsSync( localpath ) ){
+    var local = new Mergeable( defaults.export() );
+    if( true === deep ){ local.deepMergeFromPath( localpath ); }
+    else { local.shallowMergeFromPath( localpath ); }
+    return local;
+  }
   return defaults;
 };
 
 var config = {
   defaults: defaults,
-  generate: generate.bind( null, true )
+  generate: generate.bind( null, true ),
+  setLocalPath: function( path ){
+    localpath = path;
+  }
 };
 
 module.exports = config;


### PR DESCRIPTION
It would be nice for developers if pelias/config tried to load ~/pelias.json ONLY if the PELIAS_CONFIG env var is not set.

This will let me stick all my local config options in that file.
