### PR TITLE
Define a default api.accessLog value.

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -17,6 +17,9 @@
   "dbclient": {
     "statFrequency": 10000
   },
+  "api": {
+    "accessLog": "common"
+  },
   "logger": {
     "level": "info",
     "timestamp": true,

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -22,6 +22,9 @@
   "dbclient": {
     "statFrequency": 10000
   },
+  "api": {
+    "accessLog": "common"
+  },
   "logger": {
     "level": "info",
     "timestamp": true,


### PR DESCRIPTION
```
config/(defaults, expected-deep).json
	-Add a default value for the pelias/api configuration property
	introduced in https://github.com/pelias/api/pull/123 .
```

fixes pelias/api#8