### PR TITLE
add default paths for openaddresses; update ES API version

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "1.1",
+    "apiVersion": "1.7",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{
@@ -48,6 +48,12 @@
         "type": { "node": "osmnode", "way": "osmway" },
         "filename": "planet.osm.pbf"
       }]
+    },
+    "openaddresses": {
+      "datapath": "/mnt/pelias/openaddresses",
+      "files": [
+        "us-ny-nyc.csv"
+      ]
     }
   }
 }

--- a/config/env.json
+++ b/config/env.json
@@ -29,6 +29,12 @@
         "type": { "node": "osmnode", "way": "osmway" },
         "filename": "london.osm.pbf"
       }]
+    },
+    "openaddresses": {
+      "datapath": "~/openaddresses",
+      "files": [
+        "us-ny-nyc.csv"
+      ]
     }
   }
 }

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "1.1",
+    "apiVersion": "1.7",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{
@@ -53,6 +53,12 @@
          "type": { "node": "osmnode", "way": "osmway" },
          "filename": "london.osm.pbf"
       }]
+    },
+    "openaddresses": {
+      "datapath": "~/openaddresses",
+      "files": [
+        "us-ny-nyc.csv"
+      ]
     }
   }
 }

--- a/config/local.json
+++ b/config/local.json
@@ -12,6 +12,12 @@
         "type": { "node": "osmnode", "way": "osmway" },
         "filename": "london.osm.pbf"
       }]
+    },
+    "openaddresses": {
+      "datapath": "~/openaddresses",
+      "files": [
+        "us-ny-nyc.csv"
+      ]
     }
   }
 }


### PR DESCRIPTION
following on from https://github.com/pelias/openaddresses/pull/20

- add default paths for `openaddresses` imports
- update ES API version to `1.7`

@pelias/contributors if you explicitly set your `esclient.apiVersion` in `~/pelias.json` and wish to stay up-to-date with the development cycle you should now remove that setting from your local config.

you can confirm if it's set with the following command:
```bash
$ grep apiVersion ~/pelias.json
    "apiVersion": "1.3",
```

@heffergm and those running pelias in production may still opt to select the api version manually, it should correspond to the highest [available javascript api version](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/about.html) relative to what you have installed in production.

for clarity, everything still runs fine on `1.3` but developers are not able to leverage new API changes until they update their targeted version, this will likely change when `2.0` lands.