### PR TITLE
remove ny as a default file for openaddresses

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -51,9 +51,7 @@
     },
     "openaddresses": {
       "datapath": "/mnt/pelias/openaddresses",
-      "files": [
-        "us-ny-nyc.csv"
-      ]
+      "files": []
     }
   }
 }


### PR DESCRIPTION
remove ny as a default file for openaddresses