### PR TITLE
Update endpoints

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -31,7 +31,7 @@
     "endpoints": {
       "local": "http://localhost:3100/v1/",
       "dev": "http://pelias.dev.mapzen.com/v1/",
-      "prod": "http://pelias.mapzen.com/v1/",
+      "prod": "http://search.mapzen.com/v1/",
       "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/"
     }
   },

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -30,8 +30,10 @@
   "acceptance-tests": {
     "endpoints": {
       "local": "http://localhost:3100/v1/",
+      "dev-cached": "http://pelias.dev.mapzen.com.global.prod.fastly.net/v1/",
       "dev": "http://pelias.dev.mapzen.com/v1/",
       "prod": "http://search.mapzen.com/v1/",
+      "prod-uncached": "http://pelias.mapzen.com/v1/",
       "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/"
     }
   },

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -32,8 +32,7 @@
       "local": "http://localhost:3100/v1/",
       "dev": "http://pelias.dev.mapzen.com/v1/",
       "prod": "http://pelias.mapzen.com/v1/",
-      "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/",
-      "beta": "http://pelias.beta.mapzen.com/"
+      "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/"
     }
   },
   "imports": {

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -36,7 +36,7 @@
     "endpoints": {
       "local": "http://localhost:3100/v1/",
       "dev": "http://pelias.dev.mapzen.com/v1/",
-      "prod": "http://pelias.mapzen.com/v1/",
+      "prod": "http://search.mapzen.com/v1/",
       "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/"
     }
   },

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -35,8 +35,10 @@
   "acceptance-tests": {
     "endpoints": {
       "local": "http://localhost:3100/v1/",
+      "dev-cached": "http://pelias.dev.mapzen.com.global.prod.fastly.net/v1/",
       "dev": "http://pelias.dev.mapzen.com/v1/",
       "prod": "http://search.mapzen.com/v1/",
+      "prod-uncached": "http://pelias.mapzen.com/v1/",
       "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/"
     }
   },

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -37,8 +37,7 @@
       "local": "http://localhost:3100/v1/",
       "dev": "http://pelias.dev.mapzen.com/v1/",
       "prod": "http://pelias.mapzen.com/v1/",
-      "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/",
-      "beta": "http://pelias.beta.mapzen.com/"
+      "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/"
     }
   },
   "imports": {


### PR DESCRIPTION
* Change the default production URL to Fastly-backed Mapzen Search
* Add an uncached alternate production url
* Add a cached alternate dev url (dev is kept the same since we generally want uncached results)
* Remove the depricated beta endpoint