### PR TITLE
Add a peer of jshint, required by precommit-hook.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "tape": "^2.13.4",
     "tap-spec": "^0.2.0",
-    "precommit-hook": "^1.0.7"
+    "precommit-hook": "^1.0.7",
+    "jshint": "2.8.0"
   }
 }


### PR DESCRIPTION
Without this, I get 
```
npm WARN EPEERINVALID precommit-hook@1.0.7 requires a peer of jshint@ but none was installed.
```