### PR TITLE
upgrade ES API version from 1.7->2.2

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "2.2",
+    "apiVersion": "2.x",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "1.7",
+    "apiVersion": "2.2",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "2.2",
+    "apiVersion": "2.x",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "1.7",
+    "apiVersion": "2.2",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{


### PR DESCRIPTION
This PR upgrades the default elasticsearch-js API version from 1.7 to 2.2 in order to get access to all the new APIs in 2+

For the most part this won't affect us as the APIs we use have not changed (AFAIK).

I would recommend that all users update their `~/pelias.json` config (or ENV config) file to remove any mention of `esclient.apiVersion`, so they inherit the default value from the defaults file.

Connects pelias/pelias#325