### PR TITLE
Explicitly set adminLookup to false as defaults

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -39,10 +39,12 @@
   },
   "imports": {
     "geonames": {
-      "datapath": "./data"
+      "datapath": "./data",
+      "adminLookup": false
     },
     "openstreetmap": {
       "datapath": "/mnt/pelias/openstreetmap",
+      "adminLookup": false,
       "leveldbpath": "/tmp",
       "import": [{
         "filename": "planet.osm.pbf"

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -44,10 +44,12 @@
   },
   "imports": {
     "geonames": {
-      "datapath": "~/geonames"
+      "datapath": "~/geonames",
+      "adminLookup": false
     },
     "openstreetmap": {
       "datapath": "~/openstreetmap",
+      "adminLookup": false,
       "leveldbpath": "/tmp/leveldb",
       "import": [{
          "filename": "london.osm.pbf"


### PR DESCRIPTION
This will help make the settings clearer for documentation. In general
it would be great to see the defaults.json file explicitly list all
defaults.