### PR TITLE
Default to debug logging

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -23,7 +23,7 @@
     "version": "1.0"
   },
   "logger": {
-    "level": "info",
+    "level": "debug",
     "timestamp": true,
     "colorize": true
   },

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -28,7 +28,7 @@
     "version": "1.0"
   },
   "logger": {
-    "level": "info",
+    "level": "debug",
     "timestamp": true,
     "colorize": true
   },


### PR DESCRIPTION
Many many users of Pelias are confused by the lack of output at the
`info` level. Adding debug output by default will help make errors and
even successful output more clear.