### PR TITLE
feat: Add default index names for API and schema

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -20,7 +20,11 @@
   "api": {
     "accessLog": "common",
     "host": "http://pelias.mapzen.com/",
+    "indexName": "pelias",
     "version": "1.0"
+  },
+  "schema": {
+    "indexName": "pelias"
   },
   "logger": {
     "level": "debug",

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -24,8 +24,12 @@
   },
   "api": {
     "accessLog": "common",
+    "indexName": "pelias",
     "host": "http://pelias.mapzen.com/",
     "version": "1.0"
+  },
+  "schema": {
+    "indexName": "pelias"
   },
   "logger": {
     "level": "debug",


### PR DESCRIPTION
As part of https://github.com/pelias/api/issues/334, we want to be able to configure the Elasticsearch index name that is used by the API, and separately, the importers.


This is a backwards compatible config that adds configuration defaults
for Elasticsearch index names for both the API and schema (which is also
intended to be used by the importers).

While this change by itself doesn't affect anything, **it is what will determine what the config parameter names are for changing which Elasticsearch index to use**, so if there is anything confusing about the current names, this is the best time to change them.

Connects https://github.com/pelias/api/issues/334