### PR TITLE
Add default flag for WOF venue import

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -59,7 +59,8 @@
       "files": []
     },
     "whosonfirst": {
-      "datapath": "/mnt/pelias/whosonfirst"
+      "datapath": "/mnt/pelias/whosonfirst",
+      "importVenues": false
     }
   }
 }

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -66,7 +66,8 @@
       ]
     },
     "whosonfirst": {
-      "datapath": "~/whosonfirst"
+      "datapath": "~/whosonfirst",
+      "importVenues": false
     }
   }
 }


### PR DESCRIPTION
Because the venue data is quite large, this defaults to false.