### PR TITLE
Add Elasticsearch settings

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -14,6 +14,15 @@
       "level": [ "error", "warning" ]
     }]
   },
+  "elasticsearch": {
+    "settings": {
+      "index": {
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "index_concurrency": "10"
+      }
+    }
+  },
   "dbclient": {
     "statFrequency": 10000
   },

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -19,7 +19,8 @@
       "index": {
         "number_of_replicas": "0",
         "number_of_shards": "1",
-        "index_concurrency": "10"
+        "index_concurrency": "10",
+        "refresh_interval": "1m"
       }
     }
   },

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -24,7 +24,8 @@
       "index": {
         "number_of_replicas": "0",
         "number_of_shards": "1",
-        "index_concurrency": "10"
+        "index_concurrency": "10",
+        "refresh_interval": "1m"
       }
     }
   },

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -19,6 +19,15 @@
       "level": [ "error", "warning" ]
     }]
   },
+  "elasticsearch": {
+    "settings": {
+      "index": {
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "index_concurrency": "10"
+      }
+    }
+  },
   "dbclient": {
     "statFrequency": 10000
   },


### PR DESCRIPTION
These were buried in [pelias/schema](https://github.com/pelias/schema/blob/f28002db187f1685abc3688b141e0bfdd5cdd01a/settings.js#L289-L296) and will be removed in another PR.

Note that [both](https://github.com/pelias/config/commit/ac95ac8f7e258d22e2c4ced661d21f5fe2f13fba) [commits](https://github.com/pelias/config/commit/0e3fd2c63f43f1c6f4c982597173ef730668abe5) have nice big friendly commit messages with information about these settings. Because JSON doesn't have any support for comments, hopefully people will look at `git blame` when trying to find information on these settings, so I tried to include as much as possible.

Connects pelias/schema#178