### PR TITLE
fix: Set Elasticsearch API version to 2.3

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "2.x",
+    "apiVersion": "2.3",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "2.x",
+    "apiVersion": "2.3",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{


### PR DESCRIPTION
The previous target, 2.x, is going away in newer versions of the Elasticsearch NPM module, which we'd like to use. The default will [track the latest version of ES](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html#config-options) so we need to explicitly set it to 2.3.