### PR TITLE
feat: Add default country code for Geonames

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -53,7 +53,8 @@
   "imports": {
     "geonames": {
       "datapath": "./data",
-      "adminLookup": false
+      "adminLookup": false,
+      "countryCode": "ALL"
     },
     "openstreetmap": {
       "datapath": "/mnt/pelias/openstreetmap",

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -58,7 +58,8 @@
   "imports": {
     "geonames": {
       "datapath": "~/geonames",
-      "adminLookup": false
+      "adminLookup": false,
+      "countryCode": "ALL"
     },
     "openstreetmap": {
       "datapath": "~/openstreetmap",


### PR DESCRIPTION
This can be overridden once the Geonames importer supports it.