### PR TITLE
interpolation client config

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -23,6 +23,11 @@
       }
     }
   },
+  "interpolation": {
+    "client": {
+      "adapter": "null"
+    }
+  },
   "dbclient": {
     "statFrequency": 10000
   },

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -28,6 +28,11 @@
       }
     }
   },
+  "interpolation": {
+    "client": {
+      "adapter": "null"
+    }
+  },
   "dbclient": {
     "statFrequency": 10000
   },

--- a/config/local.json
+++ b/config/local.json
@@ -1,4 +1,10 @@
 {
+  "interpolation": {
+    "client": {
+      "adapter": "http",
+      "host": "http://localhost:9999"
+    }
+  },
   "imports": {
     "geonames": {
       "datapath": "/media/hdd"

--- a/test/generate.js
+++ b/test/generate.js
@@ -89,6 +89,8 @@ module.exports.generate.local = function(test) {
     t.notDeepEqual(c, defaults, 'valid function');
     t.equal(typeof c.esclient, 'object', 'valid property');
     t.equal(Object.keys(c.esclient).length, 5, 'keep all default properties');
+    t.equal(c.interpolation.client.adapter, 'http', 'interpolation client');
+    t.equal(c.interpolation.client.host, 'http://localhost:9999', 'interpolation client');
     t.equal(c.imports.geonames.datapath, '/media/hdd', 'local paths');
     t.equal(c.imports.openstreetmap.datapath, '/media/hdd/osm/mapzen-metro', 'local paths');
     t.equal(c.imports.openstreetmap.import[0].filename, 'london.osm.pbf', 'local paths');


### PR DESCRIPTION
interpolation client config

allows configuration of the interpolation client via a config such as:

```bash
  "interpolation": {
    "client": {
      "adapter": "http",
      "host": "http://localhost:9999"
    }
  },
```

with the default being:

```
  "interpolation": {
    "client": {
      "adapter": "null"
    }
  },
```

**note:** the 'adapter' value will allow for different access protocols in the future, for now the intended options will be `http` and `require`, any other option will fall back to the `NullAdapter` which simply does a no-op (out of scope for this PR, see the corresponding PR in pelias/api).