### PR TITLE
feat: Add admin lookup config section defaults

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -62,12 +62,10 @@
     },
     "geonames": {
       "datapath": "./data",
-      "adminLookup": false,
       "countryCode": "ALL"
     },
     "openstreetmap": {
       "datapath": "/mnt/pelias/openstreetmap",
-      "adminLookup": false,
       "leveldbpath": "/tmp",
       "import": [{
         "filename": "planet.osm.pbf"
@@ -75,12 +73,10 @@
     },
     "openaddresses": {
       "datapath": "/mnt/pelias/openaddresses",
-      "adminLookup": false,
       "files": []
     },
     "polyline": {
       "datapath": "/mnt/pelias/polyline",
-      "adminLookup": false,
       "files": []
     },
     "whosonfirst": {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -56,6 +56,10 @@
     }
   },
   "imports": {
+    "adminLookup": {
+      "enabled": true,
+      "maxConcurrentRequests": 100
+    },
     "geonames": {
       "datapath": "./data",
       "adminLookup": false,

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -61,6 +61,10 @@
     }
   },
   "imports": {
+    "adminLookup": {
+      "enabled": true,
+      "maxConcurrentRequests": 100
+    },
     "geonames": {
       "datapath": "~/geonames",
       "adminLookup": false,

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -67,12 +67,10 @@
     },
     "geonames": {
       "datapath": "~/geonames",
-      "adminLookup": false,
       "countryCode": "ALL"
     },
     "openstreetmap": {
       "datapath": "~/openstreetmap",
-      "adminLookup": false,
       "leveldbpath": "/tmp/leveldb",
       "import": [{
          "filename": "london.osm.pbf"
@@ -80,14 +78,12 @@
     },
     "openaddresses": {
       "datapath": "~/openaddresses",
-      "adminLookup": false,
       "files": [
         "us-ny-nyc.csv"
       ]
     },
     "polyline": {
       "datapath": "~/polyline",
-      "adminLookup": false,
       "files": [
         "road_network.polylines"
       ]


### PR DESCRIPTION
With the [recent changes](https://github.com/pelias/wof-admin-lookup/pull/89) to integrate
admin lookup into only the wof-admin-lookup, repository, we've also
added a global, instead of per-importer flag to enable admin lookup.

At the same time, we've finally come to the conclusion that admin lookup
should be enabled by default. Despite telling users to enable it after
they understand the memory consequences in our installation guide,
everyone expects cities and other admin areas in their results even when
they haven't enabled it. This makes sense, since the behavior without
admin lookup isn't as good, and the default experience should be good.

So this PR sets that global admin lookup flag to _true_, meaning all
importers will default to using admin lookup, unless it's disabled.

This should lead to a better expected experience for most users, with a
little bit of additional setup work, and more hardware, required.