### PR TITLE
generated now returns validated config with defaults and types massaged

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,14 @@ var generate = function( schema, deep ){
   const config = getConfig(deep);
 
   if (_.isObject(schema)) {
-    Joi.validate(config, schema, (err) => {
-      if (err) {
-        throw new Error(err.details[0].message);
-      }
-    });
+    const result = Joi.validate(config, schema);
+
+    if (result.error) {
+      throw new Error(result.error.details[0].message);
+    }
+
+    return result.value;
+
   }
 
   return config;

--- a/test/generate.js
+++ b/test/generate.js
@@ -201,6 +201,30 @@ module.exports.generate.validate = (test) => {
 
   });
 
+  test('returned config should have defaults applied and types converted', (t) => {
+    const localConfig = require('../');
+    localConfig.defaults.test = {
+      key_with_type_conversion: 'yes'
+    };
+
+    const schema = Joi.object().keys({
+      test: Joi.object().keys({
+        key_with_default: Joi.string().default('default value'),
+        key_with_type_conversion: Joi.boolean().default(true).truthy('yes').falsy('no'),
+        key_without_default: Joi.string()
+      })
+    }).unknown(true);
+
+    const validatedConfig = localConfig.generate(schema);
+
+    t.equals(validatedConfig.test.key_with_default, 'default value', 'default value should be used');
+    t.ok(typeof validatedConfig.test.key_with_type_conversion, 'boolean', 'should be boolean');
+    t.ok(validatedConfig.test.key_with_type_conversion, 'should be true');
+    t.equals(validatedConfig.test.key_without_default, undefined, 'no default');
+    t.end();
+
+  });
+
 };
 
 module.exports.all = function (tape) {


### PR DESCRIPTION
Previously, the supplied schema to `generate` was just validated against but we weren't taking advantage of Joi's ability to add default values and massage types.  For example, in the WOF importer, the code does this at the top: 

`var peliasConfig = require( 'pelias-config' ).generate(require('./schema'));`

but then the code would have to substitute in default values manually and know all the accepted types.  

This change returns the validated config from `generate` so the defaults are populated.  We won't have to check to see if `importVenues` was set to `yes` and then convert that to `true` since Joi does that for us.  