### PR TITLE
Default to enabling libpostal in the api

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -33,6 +33,7 @@
   },
   "api": {
     "accessLog": "common",
+    "textAnalyzer": "libpostal",
     "host": "http://pelias.mapzen.com/",
     "indexName": "pelias",
     "version": "1.0"

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -38,6 +38,7 @@
   },
   "api": {
     "accessLog": "common",
+    "textAnalyzer": "libpostal",
     "indexName": "pelias",
     "host": "http://pelias.mapzen.com/",
     "version": "1.0"


### PR DESCRIPTION
At this point, using addressit for search and structured search is
basically an unsupported configuration, since we haven't tested it in
some time. It may in fact even cause errors like those seen in
https://github.com/pelias/pelias/issues/579.