### PR TITLE
Changed default elasticsearch num of shards to 5

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -18,7 +18,7 @@
     "settings": {
       "index": {
         "number_of_replicas": "0",
-        "number_of_shards": "1",
+        "number_of_shards": "5",
         "refresh_interval": "1m"
       }
     }

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -23,7 +23,7 @@
     "settings": {
       "index": {
         "number_of_replicas": "0",
-        "number_of_shards": "1",
+        "number_of_shards": "5",
         "refresh_interval": "1m"
       }
     }


### PR DESCRIPTION
Elasticsearch uses 5 shards by default.