### PR TITLE
feat: change default Elasticsearch API version to 2.4

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "2.3",
+    "apiVersion": "2.4",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "2.3",
+    "apiVersion": "2.4",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{


### PR DESCRIPTION
Newer versions of `elasticsearch-js` ship only with support for the highest minor version of old major elasticsearch versions. This means that the newest versions have dropped support for the `2.3` API. `2.4` is the only API version supported nopw.

We currently use 2.3 in production for Mapzen Search, but as mentioned in the changelog[1], using API version 2.4 will work just fine. As defined in the rules of semver, only new API calls could be added in 2.4, so anything that works in 2.3 will still be fine.

Changing this version allows us to upgrade to newer versions of `elasticsearch-js` which support the latest versions of Elasticsearch 5, making it easier to upgrade.

[1] https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/changelog.html#_13_0_0_apr_24_2017

Connects https://github.com/pelias/api/pull/867
Connects https://github.com/pelias/pelias/issues/461