### PR TITLE
feat(targets): add API filter targets to config

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -36,7 +36,35 @@
     "textAnalyzer": "libpostal",
     "host": "http://pelias.mapzen.com/",
     "indexName": "pelias",
-    "version": "1.0"
+    "version": "1.0",
+    "targets": {
+      "layers_by_source": {
+        "openstreetmap": [ "address", "venue", "street" ],
+        "openaddresses": [ "address" ],
+        "geonames": [
+          "country", "macroregion", "region", "county", "localadmin", "locality", "borough", 
+          "neighbourhood", "venue"
+        ],
+        "whosonfirst": [
+          "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
+          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", 
+          "microhood", "disputed", "venue", "postalcode", "continent", "ocean", "marinearea"
+        ]
+      },
+      "source_aliases": {
+        "osm": [ "openstreetmap" ],
+        "oa":  [ "openaddresses" ],
+        "gn":  [ "geonames" ],
+        "wof": [ "whosonfirst" ]
+      },
+      "layer_aliases": {
+        "coarse": [
+          "continent", "empire", "country", "dependency", "macroregion", "region", "locality", 
+          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", 
+          "microhood", "disputed", "postalcode", "continent", "ocean", "marinearea"
+        ]
+      }
+    }
   },
   "schema": {
     "indexName": "pelias"

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -38,6 +38,7 @@
     "indexName": "pelias",
     "version": "1.0",
     "targets": {
+      "auto_discover": false,
       "layers_by_source": {
         "openstreetmap": [ "address", "venue", "street" ],
         "openaddresses": [ "address" ],

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -43,6 +43,7 @@
     "host": "http://pelias.mapzen.com/",
     "version": "1.0",
     "targets": {
+      "auto_discover": false,
       "layers_by_source": {
         "openstreetmap": [ "address", "venue", "street" ],
         "openaddresses": [ "address" ],

--- a/config/expected-deep.json
+++ b/config/expected-deep.json
@@ -41,7 +41,35 @@
     "textAnalyzer": "libpostal",
     "indexName": "pelias",
     "host": "http://pelias.mapzen.com/",
-    "version": "1.0"
+    "version": "1.0",
+    "targets": {
+      "layers_by_source": {
+        "openstreetmap": [ "address", "venue", "street" ],
+        "openaddresses": [ "address" ],
+        "geonames": [
+          "country", "macroregion", "region", "county", "localadmin", "locality", "borough", 
+          "neighbourhood", "venue"
+        ],
+        "whosonfirst": [
+          "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
+          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", 
+          "microhood", "disputed", "venue", "postalcode", "continent", "ocean", "marinearea"
+        ]
+      },
+      "source_aliases": {
+        "osm": [ "openstreetmap" ],
+        "oa":  [ "openaddresses" ],
+        "gn":  [ "geonames" ],
+        "wof": [ "whosonfirst" ]
+      },
+      "layer_aliases": {
+        "coarse": [
+          "continent", "empire", "country", "dependency", "macroregion", "region", "locality", 
+          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", 
+          "microhood", "disputed", "postalcode", "continent", "ocean", "marinearea"
+        ]
+      }
+    }
   },
   "schema": {
     "indexName": "pelias"


### PR DESCRIPTION
This PR moves the hard-coded list of sources/layers from the `pelias/api` codebase in to `pelias/config`.

This will allow external developers to add their own sources/layers without having to modify source code.