### PR TITLE
Replace Mergeable with Lodash

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ You can test the result of merging your env config with the following bash oneli
 ```bash
 npm install pelias-config; \
 PELIAS_CONFIG=/path/config.json \
-node -e "console.log( require('pelias-config').generate().stringify() );";
+node -e "console.log( JSON.stringify(require('pelias-config').generate(), null, 2) );";
 ```
 
 ### Validation
 
-Aside from `deep`, the `generate` function takes an additional parameter named `schema` that uses [Joi](https://www.npmjs.com/package/joi) to validate that the configuration is useable.  An error is thrown if the generated configuration does not validate against the schema.  
+Aside from `deep`, the `generate` function takes an additional parameter named `schema` that uses [Joi](https://www.npmjs.com/package/joi) to validate that the configuration is useable.  An error is thrown if the generated configuration does not validate against the schema.
 
 ### Exporting & Debugging
 
-The generated config will be a [mergeable](https://github.com/pelias/mergeable) object:
+The generated config will be a standard Javascript object:
 
 ```javascript
 var config = require('pelias-config'),
@@ -91,16 +91,15 @@ var config = require('pelias-config'),
 var copy = settings.export();
 ```
 
-You can pretty print the generated config:
+You can pretty print the generated config with any package you like or with `JSON.stringify`.
+Using the third parameter to `JSON.stringify` for indentation may be helpful:
 
 ```javascript
 var config = require('pelias-config'),
     settings = config.generate();
 
-console.log( settings.stringify() );
+console.log( JSON.stringify(settings, null, 2) );
 ```
-
-see https://github.com/pelias/mergeable for a full list of methods
 
 ## NPM Module
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
-let localpath;
 
 const Joi = require('joi');
+
+const default_config = require( __dirname + '/config/defaults.json' );
+let localpath = '~/pelias.json'; // default location of pelias.json
 
 // allow the ops guys to override settings on the server
 function generate( schema, deep ){
@@ -32,10 +34,7 @@ function generate( schema, deep ){
   }
 
   return config;
-
 }
-
-const default_config = require( __dirname + '/config/defaults.json' );
 
 function getConfig(deep) {
   // load config from ENV
@@ -53,7 +52,7 @@ function getConfig(deep) {
   }
 }
 
-var config = {
+module.exports = {
   defaults: default_config,
   generate: generate,
   setLocalPath: function( p ){
@@ -61,6 +60,3 @@ var config = {
     return localpath;
   }
 };
-
-config.setLocalPath( '~/pelias.json' );
-module.exports = config;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const Joi = require('joi');
 const default_config = require( __dirname + '/config/defaults.json' );
 let localpath = '~/pelias.json'; // default location of pelias.json
 
-// allow the ops guys to override settings on the server
+// generate the final configuration, taking into account user overrides
+// as well as preferences for deep or shallow merges
 function generate( schema, deep ){
   // if first parameter is a boolean, then it's deep, not a schema
   if (_.isBoolean(schema)) {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+const Mergeable = require('mergeable');
+const defaults = new Mergeable( __dirname + '/config/defaults.json' );
+let localpath;
 
-var fs = require('fs'),
-    path = require('path'),
-    Mergeable = require('mergeable'),
-    defaults = new Mergeable( __dirname + '/config/defaults.json' ),
-    localpath;
 const _ = require('lodash');
 const Joi = require('joi');
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const Joi = require('joi');
 
 const default_config = require( __dirname + '/config/defaults.json' );
-let localpath = '~/pelias.json'; // default location of pelias.json
+let localpath = process.env.HOME + '/pelias.json'; // default location of pelias.json
 
 // generate the final configuration, taking into account user overrides
 // as well as preferences for deep or shallow merges

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ let localpath;
 const Joi = require('joi');
 
 // allow the ops guys to override settings on the server
-var generate = function( schema, deep ){
+function generate( schema, deep ){
   // if first parameter is a boolean, then it's deep, not a schema
   if (_.isBoolean(schema)) {
     deep = schema;
@@ -33,7 +33,7 @@ var generate = function( schema, deep ){
 
   return config;
 
-};
+}
 
 const default_config = require( __dirname + '/config/defaults.json' );
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "dependencies": {
     "joi": "^13.1.2",
-    "lodash": "^4.17.4",
-    "mergeable": "0.0.0"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "jshint": "^2.9.4",

--- a/test/generate.js
+++ b/test/generate.js
@@ -70,7 +70,7 @@ module.exports.generate.production = function(test) {
     process.env.PELIAS_CONFIG = path.resolve( __dirname + '/../config/env.json' );
 
     var c = config.generate( true );
-    t.deepEqual(c.export(), expected, 'merged as expected');
+    t.deepEqual(c, expected, 'merged as expected');
     t.end();
 
     // unset the PELIAS_CONFIG env var
@@ -110,7 +110,7 @@ module.exports.generate.local = function(test) {
     config.setLocalPath( path.resolve( __dirname + '/../config/env.json' ) );
 
     var c = config.generate( true );
-    t.deepEqual(c.export(), expected, 'merged as expected');
+    t.deepEqual(c, expected, 'merged as expected');
     t.end();
 
     // reset localpath
@@ -129,7 +129,7 @@ module.exports.generate.local = function(test) {
     config.setLocalPath( path.resolve( __dirname + '/../config/local.json' ) );
 
     var c = config.generate( true );
-    t.deepEqual(c.export(), expected, 'merged as expected');
+    t.deepEqual(c, expected, 'merged as expected');
     t.equal(c.imports.geonames.datapath, '~/geonames', 'env paths still set');
     t.end();
 
@@ -151,7 +151,7 @@ module.exports.generate.paths = function(test) {
     process.env.PELIAS_CONFIG = path.resolve(__dirname + '/../config/env.json');
 
     var c = config.generate();
-    t.deepEqual(c.export(), expected, 'loaded absolute file path');
+    t.deepEqual(c, expected, 'loaded absolute file path');
     t.end();
 
     // unset the PELIAS_CONFIG env var
@@ -164,7 +164,7 @@ module.exports.generate.paths = function(test) {
     process.env.PELIAS_CONFIG = './config/env.json';
 
     var c = config.generate();
-    t.deepEqual(c.export(), expected, 'loaded relative file path');
+    t.deepEqual(c, expected, 'loaded relative file path');
     t.end();
 
     // unset the PELIAS_CONFIG env var

--- a/test/generate.js
+++ b/test/generate.js
@@ -28,22 +28,22 @@ module.exports.generate.development = function(test) {
 module.exports.generate.production = function(test) {
 
   // shallow merging disabled as deep merging should be the default
-  // test('production shallow merge', function(t) {
+  test('production shallow merge', function(t) {
 
-  //   // set the PELIAS_CONFIG env var
-  //   process.env.PELIAS_CONFIG = path.resolve( __dirname + '/../config/env.json' );
+    // set the PELIAS_CONFIG env var
+    process.env.PELIAS_CONFIG = path.resolve( __dirname + '/../config/env.json' );
 
-  //   var c = config.generate();
-  //   t.equal(typeof config, 'object', 'valid function');
-  //   t.notDeepEqual(c, defaults, 'valid function');
-  //   t.equal(typeof c.esclient, 'object', 'valid property');
-  //   t.equal(Object.keys(c.esclient).length, 1, 'deleted all default properties');
-  //   t.equal(c.esclient.hosts.length, 2, 'shallow merge');
-  //   t.end();
+    var c = config.generate(false);
+    t.equal(typeof config, 'object', 'valid function');
+    t.notDeepEqual(c, defaults, 'valid function');
+    t.equal(typeof c.esclient, 'object', 'valid property');
+    t.equal(Object.keys(c.esclient).length, 1, 'deleted all default properties');
+    t.equal(c.esclient.hosts.length, 2, 'shallow merge');
+    t.end();
 
-  //   // unset the PELIAS_CONFIG env var
-  //   delete process.env.PELIAS_CONFIG;
-  // });
+    // unset the PELIAS_CONFIG env var
+    delete process.env.PELIAS_CONFIG;
+  });
 
   test('production deep merge', function(t) {
 
@@ -55,7 +55,7 @@ module.exports.generate.production = function(test) {
     t.notDeepEqual(c, defaults, 'valid function');
     t.equal(typeof c.esclient, 'object', 'valid property');
     t.equal(Object.keys(c.esclient).length, 5, 'keep all default properties');
-    t.equal(c.esclient.hosts.length, 2, 'deep merge');
+    t.equal(c.esclient.hosts.length, 2, 'deep merge should set two hosts');
     t.end();
 
     // unset the PELIAS_CONFIG env var

--- a/test/generate.js
+++ b/test/generate.js
@@ -27,8 +27,7 @@ module.exports.generate.development = function(test) {
 
 module.exports.generate.production = function(test) {
 
-  // shallow merging disabled as deep merging should be the default
-  test('production shallow merge', function(t) {
+  test('explicit shallow merge', function(t) {
 
     // set the PELIAS_CONFIG env var
     process.env.PELIAS_CONFIG = path.resolve( __dirname + '/../config/env.json' );
@@ -45,12 +44,27 @@ module.exports.generate.production = function(test) {
     delete process.env.PELIAS_CONFIG;
   });
 
-  test('production deep merge', function(t) {
-
+  test('explicit deep merge', function(t) {
     // set the PELIAS_CONFIG env var
     process.env.PELIAS_CONFIG = path.resolve( __dirname + '/../config/env.json' );
 
     var c = config.generate( true );
+    t.equal(typeof config, 'object', 'valid function');
+    t.notDeepEqual(c, defaults, 'valid function');
+    t.equal(typeof c.esclient, 'object', 'valid property');
+    t.equal(Object.keys(c.esclient).length, 5, 'keep all default properties');
+    t.equal(c.esclient.hosts.length, 2, 'deep merge should set two hosts');
+    t.end();
+
+    // unset the PELIAS_CONFIG env var
+    delete process.env.PELIAS_CONFIG;
+  });
+
+  test('default merge, should be a deep merge', function(t) {
+    // set the PELIAS_CONFIG env var
+    process.env.PELIAS_CONFIG = path.resolve( __dirname + '/../config/env.json' );
+
+    var c = config.generate();
     t.equal(typeof config, 'object', 'valid function');
     t.notDeepEqual(c, defaults, 'valid function');
     t.equal(typeof c.esclient, 'object', 'valid property');


### PR DESCRIPTION
The [pelias/mergeable](https://github.com/pelias/mergeable) package is not really maintained, and doesn't do anything Lodash can't.

In the interests of reducing the number of packages and amount of code we maintain, this PR replaces Mergeable with Lodash in this package.

**Note:** Before merging this, we should check that none of our other packages use any of the [interface functions](https://github.com/pelias/mergeable#interface) Mergeable provides, as the result of a config is now a plain old Javascript object.

Attempt number 2, as I got the semantic release tag wrong initially.

Connects https://github.com/pelias/mergeable/issues/5