### PR TITLE
fix(PELIAS_CONFIG): properly suport relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function getConfig(deep) {
   // load config from ENV
   let custom_config;
   if( process.env.hasOwnProperty('PELIAS_CONFIG') ){
-    custom_config = require( process.env.PELIAS_CONFIG );
+    custom_config = require( path.resolve(process.env.PELIAS_CONFIG) );
   } else if ( fs.existsSync (localpath) ) {
     custom_config = require( localpath );
   }

--- a/test/generate.js
+++ b/test/generate.js
@@ -185,6 +185,19 @@ module.exports.generate.paths = function(test) {
     delete process.env.PELIAS_CONFIG;
   });
 
+  test('relative paths supported from any location', function (t) {
+    process.chdir('./config');
+    // set the relative PELIAS_CONFIG env var
+    process.env.PELIAS_CONFIG = './env.json';
+
+    var c = config.generate();
+    t.deepEqual(c, expected, 'loaded relative file path');
+    t.end();
+
+    // unset the PELIAS_CONFIG env var
+    delete process.env.PELIAS_CONFIG;
+  });
+
   test('invalid paths in ENV var throws exception', function (t) {
 
     // set the relative PELIAS_CONFIG env var


### PR DESCRIPTION
Usage of `path.resolve` was erroneously removed in https://github.com/pelias/config/pull/89.

Without `path.resolve`, relative paths are evaluated as relative to the location of the `pelias-config` module, not the current working directory, as is likely intended.