### PR TITLE
feat(release): replace semantic-release dep with Travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ matrix:
 script: npm run travis
 before_install:
   - npm i -g npm
-after_success:
-  - npx semantic-release
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
+jobs:
+  include:
+    - stage: release
+      node_js: 10
+      script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
+      if: branch = master

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "jshint": "^2.9.4",
     "precommit-hook": "^3.0.0",
-    "semantic-release": "^15.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^4.5.0"
   },


### PR DESCRIPTION
This change moves semantic-release out of dev-dependencies, but keeps
its functionality by calling semantic-release as usual in a `release`
TravisCI build stage. There are several advantages to this method:

1.) semantic-release is run only after all builds succeed. Our previous
approach could have theoretically run semantic-release when some Node.js
versions failed with the current code
2.) semantic-release (and it's many dependencies) are removed from
`node_modules`. This increases the speed of `npm install` in all cases,
and reduces the size of our Docker images by 20MB (from 284MB to 264MB)!
Since the only time semantic-release is needed is on TravisCI anyway, it
seems pointless that every installation of Pelias should include it.
3.) Because semantic-release is not in `package.json`, Greenkeeper will
not attempt to update it. Semantic release updates _very_ frequently,
and each update attempt seems to have a decent chance of experiencing a
random TravisCI failure, causing unwanted notifications.

This change also lets us configure the script to run in one place, the
new pelias/ci-repo.

Connects https://github.com/pelias/api/pull/1187, where this was first
tried.