### PR TITLE
Set default for JSON logs

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -11,6 +11,7 @@
     }],
     "log": [{
       "type": "stdio",
+      "json": false,
       "level": [ "error", "warning" ]
     }]
   },

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -16,6 +16,7 @@
     }],
     "log": [{
       "type": "stdio",
+      "json": false,
       "level": [ "error", "warning" ]
     }]
   },


### PR DESCRIPTION
This is a default value for the change in https://github.com/pelias/logger/pull/47
that allows logs to be configured to be emitted as JSON.

Adding the current default value, which keeps JSON logs disabled to
avoid making any changes, will help make things more clear.