### PR TITLE
feat(gid_blacklist): add default config

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -44,12 +44,12 @@
         "openstreetmap": [ "address", "venue", "street" ],
         "openaddresses": [ "address" ],
         "geonames": [
-          "country", "macroregion", "region", "county", "localadmin", "locality", "borough", 
+          "country", "macroregion", "region", "county", "localadmin", "locality", "borough",
           "neighbourhood", "venue"
         ],
         "whosonfirst": [
           "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
-          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", 
+          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood",
           "microhood", "disputed", "venue", "postalcode", "continent", "ocean", "marinearea"
         ]
       },
@@ -61,8 +61,8 @@
       },
       "layer_aliases": {
         "coarse": [
-          "continent", "empire", "country", "dependency", "macroregion", "region", "locality", 
-          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", 
+          "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
+          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood",
           "microhood", "disputed", "postalcode", "continent", "ocean", "marinearea"
         ]
       }
@@ -90,6 +90,9 @@
     "adminLookup": {
       "enabled": true,
       "maxConcurrentRequests": 100
+    },
+    "blacklist": {
+      "files": []
     },
     "geonames": {
       "datapath": "./data",

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -49,12 +49,12 @@
         "openstreetmap": [ "address", "venue", "street" ],
         "openaddresses": [ "address" ],
         "geonames": [
-          "country", "macroregion", "region", "county", "localadmin", "locality", "borough", 
+          "country", "macroregion", "region", "county", "localadmin", "locality", "borough",
           "neighbourhood", "venue"
         ],
         "whosonfirst": [
           "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
-          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", 
+          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood",
           "microhood", "disputed", "venue", "postalcode", "continent", "ocean", "marinearea"
         ]
       },
@@ -66,8 +66,8 @@
       },
       "layer_aliases": {
         "coarse": [
-          "continent", "empire", "country", "dependency", "macroregion", "region", "locality", 
-          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", 
+          "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
+          "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood",
           "microhood", "disputed", "postalcode", "continent", "ocean", "marinearea"
         ]
       }
@@ -95,6 +95,9 @@
     "adminLookup": {
       "enabled": true,
       "maxConcurrentRequests": 100
+    },
+    "blacklist": {
+      "files": []
     },
     "geonames": {
       "datapath": "~/geonames",


### PR DESCRIPTION
I played around with this a bit and in the end just went for something simple:

```javascript
  "imports": {
    "blacklist": {
      "files": []
    },
```

This conforms to the property names, where `files: []` is used.

---

I also considered offering the ability to specify GIDs as strings as well as in external files, as such:

```javascript
  "imports": {
    "blacklist": {
      "gids": [ "whosonfirst:localadmin:404428881" ],
      "files": [ "/tmp/foo.txt" ]
    },
```

or like this:

```javascript
  "imports": {
    "blacklist": {
      "gids": [
                    "whosonfirst:localadmin:404428881",
                    "file:///tmp/foo.txt"
      ]
    },
```

---

The term 'blacklist' is also not very intuative, nesting it under `imports` makes it a little better, it's not clear that this setting only applies to `GIDs`.

---

The other thing I considered is making it more general purpose, something like:

```javascript
  "imports": {
    "overrides": {
      "exclude": []
    },
```

... but that likely isn't nessesary as we could include another child of `imports` at a later date if required.