### PR TITLE
feat(get): add get helper method

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,17 @@ function generate( schema, deep ){
     deep = true;
   }
 
+  const getFunction = function get(key) {
+    return _.get(this, key);
+  };
+
   const config = getConfig(deep);
+
+  // set 'get' convenience function on returned object
+  Object.defineProperty(config, 'get', {
+    value: getFunction,
+    enumerable: false // allows comparison to `expected.json` in tests
+  });
 
   if (_.isObject(schema)) {
     const result = Joi.validate(config, schema);

--- a/test/generate.js
+++ b/test/generate.js
@@ -252,6 +252,20 @@ module.exports.generate.validate = (test) => {
 
   });
 
+  test('get function allows getting keys which are set and undefined for unset', (t) => {
+    // set the PELIAS_CONFIG env var
+    process.env.PELIAS_CONFIG = path.resolve( __dirname + '/../config/env.json' );
+    const c = config.generate();
+
+    t.equals(c.get('logger.level'), 'debug', 'get can get keys that exist');
+    t.equals(c.get('deeply.nested.path.that.does.not.exist'), undefined, 'get returns undefined for non-existent nested paths');
+
+    // unset the PELIAS_CONFIG env var
+    delete process.env.PELIAS_CONFIG;
+
+    t.end();
+  });
+
 };
 
 module.exports.all = function (tape) {


### PR DESCRIPTION
This adds a `.get()` function to all config objects made with `generate()`.

Like [Lodash _.get](https://lodash.com/docs/4.17.4#get) it allows easily fetching nested keys in objects with safe handling of undefined values.