### PR TITLE
Fix schema validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,17 +24,20 @@ function generate( schema, deep ){
   const config = getConfig(deep);
 
   if (_.isObject(schema)) {
-    const result = Joi.validate(config, schema);
-
-    if (result.error) {
-      throw new Error(result.error.details[0].message);
-    }
-
-    return result.value;
-
+    return getValidatedSchema(config, schema);
   }
 
   return config;
+}
+
+function getValidatedSchema(config, schema) {
+  const validationResult = Joi.validate(config, schema);
+
+  if (validationResult.error) {
+    throw new Error(validationResult.error.details[0].message);
+  }
+
+  return addGetFunction(validationResult.value);
 }
 
 function generateDefaults() {

--- a/test/generate.js
+++ b/test/generate.js
@@ -227,6 +227,9 @@ module.exports.generate.validate = (test) => {
     t.doesNotThrow(() => {
       config.generate(schema);
     });
+
+    const c = config.generate(schema);
+    t.equals(typeof c.get, 'function', 'config has get function');
     t.end();
   });
 

--- a/test/generate.js
+++ b/test/generate.js
@@ -221,11 +221,13 @@ module.exports.generate.validate = (test) => {
   });
 
   test('validating schema should not throw an error', (t) => {
+    const schema  = Joi.object().keys({
+      imports: Joi.object()
+    }).unknown(true);
     t.doesNotThrow(() => {
-      config.generate(Joi.object().unknown(true));
+      config.generate(schema);
     });
     t.end();
-
   });
 
   test('returned config should have defaults applied and types converted', (t) => {


### PR DESCRIPTION
If a schema was passed for validation, the returned config object did not have the `get` function defined.

This adds a helper method for schema validation which ensures the resulting config object is correct.
