### PR TITLE
feat(importers): Add empty "csv" section to config

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -96,6 +96,8 @@
     "blacklist": {
       "files": []
     },
+    "csv": {
+    },
     "geonames": {
       "datapath": "./data",
       "countryCode": "ALL"

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -101,6 +101,8 @@
     "blacklist": {
       "files": []
     },
+    "csv": {
+    },
     "geonames": {
       "datapath": "~/geonames",
       "countryCode": "ALL"


### PR DESCRIPTION
The csv-importer's config validation requires the "csv" section is at least present.

Connects https://github.com/pelias/docker/pull/27