### PR TITLE
Make Elasticsearch 5.6 the default

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "2.4",
+    "apiVersion": "5.6",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "2.4",
+    "apiVersion": "5.6",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{


### PR DESCRIPTION
This is the official last step to finish up https://github.com/pelias/pelias/issues/461 and mark Elasticsearch 5 as the default version for Pelias.

It allows us to start work on support for Elasticsearch 6 and upgrade to elasticsearch-js 16.x

Connects https://github.com/pelias/pelias/issues/461
Connects https://github.com/pelias/schema/pull/360
Connects https://github.com/pelias/api/pull/1286
Fixes https://github.com/pelias/pelias/issues/461