### PR TITLE
set elasticsearch6 as default

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "5.6",
+    "apiVersion": "6.8",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "5.6",
+    "apiVersion": "6.8",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{


### PR DESCRIPTION
this PR updates the config to use the elasticsearch v6 APIs by default