### PR TITLE
support for dynamically specifying the elasticsearch _type from config

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -16,6 +16,7 @@
     }]
   },
   "elasticsearch": {
+    "_type": "doc",
     "settings": {
       "index": {
         "number_of_replicas": "0",

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -21,6 +21,7 @@
     }]
   },
   "elasticsearch": {
+    "_type": "doc",
     "settings": {
       "index": {
         "number_of_replicas": "0",


### PR DESCRIPTION
the static type declaration in [pelias/model](https://github.com/pelias/model/blob/203ce7952c6848ca47bb5b93acc69cc9711a0af3/Document.js#L146-L149) makes it very hard to test forwards compatibility with ES7.

this PR introduces a new variable which can be read from within `pelias/schema` & `pelias/model` to control the name of the `_type` name at runtime.

I'll write up some more on the `pelias/model` ticket but the motivation is being *able to* create indices compatible with ES7 while not yet breaking backwards support for ES5.

I see this as a fairly temporary measure and once we've dropped support for ES5 we can remove this setting again (at that stage `_type` will no longer be a 'thing' in ES anyway).

But for now, it's essential for being able to test code across the breaking change.