### PR TITLE
support for dynamically specifying the elasticsearch _type from config

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -16,7 +16,6 @@
     }]
   },
   "elasticsearch": {
-    "_type": "doc",
     "settings": {
       "index": {
         "number_of_replicas": "0",
@@ -70,7 +69,8 @@
     }
   },
   "schema": {
-    "indexName": "pelias"
+    "indexName": "pelias",
+    "typeName": "doc"
   },
   "logger": {
     "level": "debug",

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -21,7 +21,6 @@
     }]
   },
   "elasticsearch": {
-    "_type": "doc",
     "settings": {
       "index": {
         "number_of_replicas": "0",
@@ -75,7 +74,8 @@
     }
   },
   "schema": {
-    "indexName": "pelias"
+    "indexName": "pelias",
+    "typeName": "doc"
   },
   "logger": {
     "level": "debug",


### PR DESCRIPTION
unfortunately, I made a mistake in https://github.com/pelias/config/pull/118

I missed that there is a `schema` section in the config which contains the target `_index` name.
It seems this is a much better place for the variable so I'm moved it there for consistency.

Luckily it hasn't been implemented anywhere yet :)

If you came here from a `git blame`, please check out https://github.com/pelias/config/pull/118 for more info.