### PR TITLE
Remove Mapzen services from default endpoints

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -79,12 +79,7 @@
   },
   "acceptance-tests": {
     "endpoints": {
-      "local": "http://localhost:3100/v1/",
-      "dev-cached": "http://pelias.dev.mapzen.com.global.prod.fastly.net/v1/",
-      "dev": "http://pelias.dev.mapzen.com/v1/",
-      "prod": "http://search.mapzen.com/v1/",
-      "prod-uncached": "http://pelias.mapzen.com/v1/",
-      "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/"
+      "local": "http://localhost:3100/v1/"
     }
   },
   "imports": {

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -84,12 +84,7 @@
   },
   "acceptance-tests": {
     "endpoints": {
-      "local": "http://localhost:3100/v1/",
-      "dev-cached": "http://pelias.dev.mapzen.com.global.prod.fastly.net/v1/",
-      "dev": "http://pelias.dev.mapzen.com/v1/",
-      "prod": "http://search.mapzen.com/v1/",
-      "prod-uncached": "http://pelias.mapzen.com/v1/",
-      "prodbuild": "http://pelias.prodbuild.mapzen.com/v1/"
+      "local": "http://localhost:3100/v1/"
     }
   },
   "imports": {


### PR DESCRIPTION
None of these URLs have worked in two years, and there's really no
reason for them to be the default.

Connects https://github.com/pelias/pelias/issues/703