### PR TITLE
feat(elasticsearch): Default to `_doc` as type name for ES7 support

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -70,7 +70,7 @@
   },
   "schema": {
     "indexName": "pelias",
-    "typeName": "doc"
+    "typeName": "_doc"
   },
   "logger": {
     "level": "debug",

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -75,7 +75,7 @@
   },
   "schema": {
     "indexName": "pelias",
-    "typeName": "doc"
+    "typeName": "_doc"
   },
   "logger": {
     "level": "debug",


### PR DESCRIPTION
Now that we have dropped support for ES5, we can change the default type name from `doc` to `_doc`. Either setting is compatible with ES6, but only `_doc` is compatible with ES7.

This change has already been set in all the Docker projects via https://github.com/pelias/docker/pull/148, so this change is already well tested.

Connects https://github.com/pelias/pelias/issues/831