### PR TITLE
feat(config): Default `whosonfirst.importPostalcodes` to true

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -114,6 +114,7 @@
     },
     "whosonfirst": {
       "datapath": "/mnt/pelias/whosonfirst",
+      "importPostalcodes": true,
       "importVenues": false
     }
   }

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -123,6 +123,7 @@
     },
     "whosonfirst": {
       "datapath": "~/whosonfirst",
+      "importPostalcodes": true,
       "importVenues": false
     }
   }


### PR DESCRIPTION
These take very little additional space, and are quite useful.

We should have enabled this a long time ago.

Closes https://github.com/pelias/config/issues/61