### PR TITLE
fix(esclient): default esclient.apiVersion to 7.x

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.x",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -1,6 +1,6 @@
 {
   "esclient": {
-    "apiVersion": "6.8",
+    "apiVersion": "7.x",
     "keepAlive": true,
     "requestTimeout": "120000",
     "hosts": [{


### PR DESCRIPTION
default `esclient.apiVersion` to 7.x