### PR TITLE
default targets.auto_discover=true

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -38,7 +38,7 @@
     "indexName": "pelias",
     "version": "1.0",
     "targets": {
-      "auto_discover": false,
+      "auto_discover": true,
       "canonical_sources": ["whosonfirst", "openstreetmap", "openaddresses", "geonames"],
       "layers_by_source": {
         "openstreetmap": [ "address", "venue", "street" ],

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -43,7 +43,7 @@
     "host": "http://pelias.mapzen.com/",
     "version": "1.0",
     "targets": {
-      "auto_discover": false,
+      "auto_discover": true,
       "canonical_sources": ["whosonfirst", "openstreetmap", "openaddresses", "geonames"],
       "layers_by_source": {
         "openstreetmap": [ "address", "venue", "street" ],


### PR DESCRIPTION
I would like to change the default value of [targets.auto_discover](https://github.com/pelias/api#custom-sources-and-layers) from `false` to `true`.

It seems like in the majority of cases having `auto_discover=true` is preferable, the only case where this setting is not preferable is when running a very large index (like planet-wide) using only canonical sources (like Geocode Earth does).

There is a small startup delay of a couple seconds in those 'enterprise-level' installations of Pelias, and the concern is that the server would announce 'ready' to a load-balancer before it loaded its sources/layers from the DB.
> note: canonical sources/layers are used until the auto_discover request returns, so the server can still respond to traffic

I think this setting would be better off defaulting to `true` and that advanced users can set it to `false` rather than the inverse?
It's really easy for developers to miss this setting when importing custom data, so this would reduce the bug reports.

Thoughts/feels?

cc/ @pelias/contributors 