### PR TITLE
Remove default value for `imports.whosonfirst.importVenues`

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -114,8 +114,7 @@
     },
     "whosonfirst": {
       "datapath": "/mnt/pelias/whosonfirst",
-      "importPostalcodes": true,
-      "importVenues": false
+      "importPostalcodes": true
     }
   }
 }

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -123,8 +123,7 @@
     },
     "whosonfirst": {
       "datapath": "~/whosonfirst",
-      "importPostalcodes": true,
-      "importVenues": false
+      "importPostalcodes": true
     }
   }
 }


### PR DESCRIPTION
This is now a deprecated options.

related: pelias/whosonfirst#487