### PR TITLE
feat: Enable Postal Cities by default

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -86,7 +86,7 @@
     "adminLookup": {
       "enabled": true,
       "maxConcurrentRequests": 100,
-      "usePostalCities": false
+      "usePostalCities": true
     },
     "blacklist": {
       "files": []

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -91,7 +91,7 @@
     "adminLookup": {
       "enabled": true,
       "maxConcurrentRequests": 100,
-      "usePostalCities": false
+      "usePostalCities": true
     },
     "blacklist": {
       "files": []


### PR DESCRIPTION
For quite a while now we've had a solution to the "Postal Cities problem" (https://github.com/pelias/pelias/issues/396), but it was disabled by default.

Enough time has passed that it should probably be enabled.

Closes https://github.com/pelias/pelias/issues/396