### PR TITLE
support for lodash get defaultValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,15 +74,14 @@ function getConfig(deep) {
 /*
  * Because it's not enumberable, the get function has to be added every time after
  * cloning an object with _.merge or _.assign
+ *
+ * see: https://lodash.com/docs/4.17.15#get
  */
 function addGetFunction(object) {
-  const getFunction = function get(key) {
-    return _.get(this, key);
-  };
 
   // set 'get' convenience function on returned object
   Object.defineProperty(object, 'get', {
-    value: getFunction,
+    value: _.get.bind(null, object),
     enumerable: false // allows comparison to `expected.json` in tests
   });
 

--- a/test/generate.js
+++ b/test/generate.js
@@ -1,7 +1,7 @@
 
-var path = require('path'),
-    config = require('../'),
-    defaults = require('../config/defaults');
+const path = require('path');
+const config = require('../');
+const defaults = require('../config/defaults');
 const Joi = require('@hapi/joi');
 
 module.exports.generate = {};
@@ -264,6 +264,19 @@ module.exports.generate.validate = (test) => {
 
     t.equals(c.get('logger.level'), 'debug', 'get can get keys that exist');
     t.equals(c.get('deeply.nested.path.that.does.not.exist'), undefined, 'get returns undefined for non-existent nested paths');
+
+    // unset the PELIAS_CONFIG env var
+    delete process.env.PELIAS_CONFIG;
+
+    t.end();
+  });
+
+  test('get function supports defaultValue', (t) => {
+    // set the PELIAS_CONFIG env var
+    process.env.PELIAS_CONFIG = path.resolve(__dirname + '/../config/env.json');
+    const c = config.generate();
+
+    t.equals(c.get('foo', 'DEFAULT'), 'DEFAULT', 'default value used for keys that do not exist');
 
     // unset the PELIAS_CONFIG env var
     delete process.env.PELIAS_CONFIG;


### PR DESCRIPTION
I noticed today that we have code such as:
`config.get('imports.whosonfirst.dataHost') || DATA_GEOCODE_EARTH_URL`

I tried to update this to use the `$defaultValue` argument provided by lodash (third arg):
`config.get('imports.whosonfirst.dataHost', DATA_GEOCODE_EARTH_URL)`

... but to my surprise this isn't supported!
this PR uses `bind` to ensure that we are supporting all arguments of the lodash function `_.get()`

https://lodash.com/docs/4.17.15#get

I don't think this alone justifies the cascading `npm` upgrade dance but maybe we can merge this at the same time as we're next doing that anyway 😄 