### PR TITLE
Remove duplicate `continent` entry

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -50,7 +50,7 @@
         "whosonfirst": [
           "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
           "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood",
-          "microhood", "disputed", "venue", "postalcode", "continent", "ocean", "marinearea"
+          "microhood", "disputed", "venue", "postalcode", "ocean", "marinearea"
         ]
       },
       "source_aliases": {
@@ -63,7 +63,7 @@
         "coarse": [
           "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
           "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood",
-          "microhood", "disputed", "postalcode", "continent", "ocean", "marinearea"
+          "microhood", "disputed", "postalcode", "ocean", "marinearea"
         ]
       }
     }

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -55,7 +55,7 @@
         "whosonfirst": [
           "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
           "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood",
-          "microhood", "disputed", "venue", "postalcode", "continent", "ocean", "marinearea"
+          "microhood", "disputed", "venue", "postalcode", "ocean", "marinearea"
         ]
       },
       "source_aliases": {
@@ -68,7 +68,7 @@
         "coarse": [
           "continent", "empire", "country", "dependency", "macroregion", "region", "locality",
           "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood",
-          "microhood", "disputed", "postalcode", "continent", "ocean", "marinearea"
+          "microhood", "disputed", "postalcode", "ocean", "marinearea"
         ]
       }
     }


### PR DESCRIPTION
For some time, apparently, there have been two `continent` entries in some of our default layer configuration data. Overall, this hasn't had any significant negative effect, since this list is mostly used in places that eventually de-duplicate it.

Worst case, some Elasticsearch filters and error messages have listed the continent layer twice, which is redundant but not going to break anything.

It's obviously better fixed though, and makes writing some API unit tests a bit simpler :)