### PR TITLE
oa: add shared community token

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -106,6 +106,7 @@
     },
     "openaddresses": {
       "datapath": "/mnt/pelias/openaddresses",
+      "token": "oa.bbbcf5787bb4251445883cc417f811ba02b9fd64809fd56c5a972171fbcfb2f6",
       "files": []
     },
     "polyline": {

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -111,6 +111,7 @@
     },
     "openaddresses": {
       "datapath": "~/openaddresses",
+      "token": "oa.bbbcf5787bb4251445883cc417f811ba02b9fd64809fd56c5a972171fbcfb2f6",
       "files": [
         "us-ny-nyc.csv"
       ]


### PR DESCRIPTION
This PR adds a default OpenAddresses token which can be used to authenticate downloads to `batch.openaddresses.io`.

One of the changes from the legacy `results.openaddresses.io` domain to the new `batch` domain was the introduction of token credentials for downloads. The purpose of this change was to better track and prevent abuse of the download server.

Requiring each new Pelias user to register their own account at https://batch.openaddresses.io would add some unnecessary friction to the new user onboarding experience with Pelias.

After discussing this with the OA team we settled on this idea of having a *default shared credential* which will 'just work' out-of-the-box.

Using this default token comes with some caveats that users should be aware of:
- throttling/bandwidth limits will be shared between all users of the shared token
- abuse of the token may result in temporary suspension or termination of the credential.
- as such, use of the shared token comes with no guarantees

Anyone serious about their installation (ie. beyond just 'playing around with it') **should register their own account and mint their own individual token** at https://batch.openaddresses.io. Doing so will mitigate the issues above by providing individual tracking and abuse prevention measures by the OA team.

Additionally, there are some features which are only available to financial sponsors of the OA project, for example, as a `>$100/mo` sponsor, Geocode Earth will be able to access downloads directly from AWS S3. We will aim to automatically detect and support these 'sponsor-level features'. Please consider financially supporting the OA project if your business depends on their work (the bandwidth bills alone are significant).

Once you've minted your own token, it's a simple matter of editing your `pelias.json` file and setting `imports.openaddresses.token={YOUR_TOKEN}`, Pelias will pick up your individual token and use it instead of the default token.