### PR TITLE
Adding the option for configuring the batch size.

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -30,7 +30,8 @@
     }
   },
   "dbclient": {
-    "statFrequency": 10000
+    "statFrequency": 10000,
+    "batchSize": 500
   },
   "api": {
     "accessLog": "common",

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -35,7 +35,8 @@
     }
   },
   "dbclient": {
-    "statFrequency": 10000
+    "statFrequency": 10000,
+    "batchSize": 500
   },
   "api": {
     "accessLog": "common",


### PR DESCRIPTION
:wave:
We are using `pelias-csv-importer` to import the huge dataset into `elasticsearch`
We have experienced that the performance is not optimal with the current batch size, given our resources.

---
#### Here's the reason for this change :rocket:

In the process of improving the performance of import, we have experienced that there is no way to configure the batch size when making the bulk import request to elasticsearch via `pelias-dbclient`.
The `pelias-csv-importer` is using the `pelias-dbclient` which has the batch size of 500 hardcoded in the `Batch.js`.
It would be nice to make it configurable.

---
#### Here's what actually got changed :clap:

Added the batchSize configuration option under dbclient configuration, and defaults it to 500 as it is in the `pelias-dbclient` now.

---
#### After this PR get merged

I have created the [PR#125](https://github.com/pelias/dbclient/pull/125) on `pelias-dbclient` to use this configuration option. I need to update that PR with the latest version of `pelias-config`.
I also need to make a PR on the `pelias-csv-importer` to update the versions of `pelias-config` and `pelias-dbclient` to use this configuration option.