### PR TITLE
Adding addendum namespaces config

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -72,6 +72,7 @@
     "indexName": "pelias",
     "typeName": "_doc"
   },
+  "addendum_namespaces": {},
   "logger": {
     "level": "debug",
     "timestamp": true,

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
-
-const Joi = require('@hapi/joi');
+const global_schema = require('./schema');
 
 const default_config = require( __dirname + '/config/defaults.json' );
 let localpath = process.env.HOME + '/pelias.json'; // default location of pelias.json
@@ -23,7 +22,9 @@ function generate( schema, deep ){
 
   const config = getConfig(deep);
 
-  if (_.isObject(schema)) {
+  // Pelias-config is always an object, so we don't expect
+  // any other joi schema type.
+  if (_.isObject(schema) && schema.type === 'object') {
     return getValidatedSchema(config, schema);
   }
 
@@ -31,7 +32,8 @@ function generate( schema, deep ){
 }
 
 function getValidatedSchema(config, schema) {
-  const validationResult = schema.validate(config);
+  const commonSchema = global_schema.concat(schema);
+  const validationResult = commonSchema.validate(config);
 
   if (validationResult.error) {
     throw new Error(validationResult.error.details[0].message);

--- a/schema.js
+++ b/schema.js
@@ -1,0 +1,9 @@
+const Joi = require('@hapi/joi');
+
+module.exports = Joi.object().keys({
+  addendum_namespaces: Joi.object().pattern(
+    Joi.string().min(2), Joi.object().required().keys({
+      type: Joi.string().valid('array', 'number', 'string', 'boolean').required()
+    })
+  )
+}).unknown(true);

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -77,6 +77,7 @@
     "indexName": "pelias",
     "typeName": "_doc"
   },
+  "addendum_namespaces": {},
   "logger": {
     "level": "debug",
     "timestamp": true,

--- a/test/generate.js
+++ b/test/generate.js
@@ -1,4 +1,3 @@
-
 const path = require('path');
 const config = require('../');
 const defaults = require('../config/defaults');
@@ -212,14 +211,6 @@ module.exports.generate.paths = function(test) {
 };
 
 module.exports.generate.validate = (test) => {
-  test('non-validating schema should throw an error', (t) => {
-    t.throws(() => {
-      config.generate(Joi.boolean());
-    }, /"value" must be a boolean/);
-    t.end();
-
-  });
-
   test('validating schema should not throw an error', (t) => {
     const schema  = Joi.object().keys({
       imports: Joi.object()
@@ -284,7 +275,7 @@ module.exports.generate.validate = (test) => {
     t.end();
   });
 
-  test('generateDefaults returns default config always', function(t) {
+  test('generateDefaults returns default config always', (t) => {
     // set the PELIAS_CONFIG env var, this config should NOT be used
     process.env.PELIAS_CONFIG = path.resolve( __dirname + '/../config/env.json' );
 
@@ -297,7 +288,7 @@ module.exports.generate.validate = (test) => {
     delete process.env.PELIAS_CONFIG;
   });
 
-  test('generateCustom returns defaults with custom settings overridden', function(t) {
+  test('generateCustom returns defaults with custom settings overridden', (t) => {
     const custom_config = {
       api: {
         customValue: 1, //add a new setting

--- a/test/run.js
+++ b/test/run.js
@@ -4,7 +4,8 @@ var common = {};
 
 var tests = [
   require('./interface.js'),
-  require('./generate.js')
+  require('./generate.js'),
+  require('./schema.js')
 ];
 
 tests.map(function(t) {

--- a/test/schema.js
+++ b/test/schema.js
@@ -1,0 +1,126 @@
+const schema = require('../schema');
+
+module.exports.tests = {};
+
+module.exports.tests.addendum_namespaces_validation = (test) => {
+  test( 'addendum_namespaces should be of object type', (t) => {
+    const config = {
+      addendum_namespaces: {
+        tariff_zone_ids: '123'
+      }
+    };
+
+    const result = schema.validate(config);
+
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"addendum_namespaces.tariff_zone_ids" must be of type object');
+    t.end();
+
+  });
+
+  test( 'addendum_namespaces of type other than array, string , boolean and number, should not be acceptable', (t) => {
+    const config = {
+      addendum_namespaces: {
+        tariff_zone_ids: {
+          type: 'object'
+        }
+      }
+    };
+
+    const result = schema.validate(config);
+
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"addendum_namespaces.tariff_zone_ids.type" must be one of [array, number, string, boolean]');
+    t.end();
+
+  });
+
+  test( 'addendum_namespaces name should be at least 2 characters', (t) => {
+    const config = {
+      addendum_namespaces: {
+        t: {
+          type: 'object'
+        }
+      }
+    };
+
+    const result = schema.validate(config);
+
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"addendum_namespaces.t" is not allowed');
+    t.end();
+  });
+
+  test( 'addendum_namespaces of type array should be acceptable', (t) => {
+    const config = {
+      addendum_namespaces: {
+        tariff_zone_ids: {
+          type: 'array'
+        }
+      }
+    };
+
+    const result = schema.validate(config);
+
+    t.notOk(result.error);
+    t.end();
+
+  });
+
+  test( 'addendum_namespaces of type string should be acceptable', (t) => {
+    const config = {
+      addendum_namespaces: {
+        tariff_zone_ids: {
+          type: 'string'
+        }
+      }
+    };
+
+    const result = schema.validate(config);
+
+    t.notOk(result.error);
+    t.end();
+  });
+
+  test( 'addendum_namespaces of type number should be acceptable', function(t) {
+    const config = {
+      addendum_namespaces: {
+        tariff_zone_ids: {
+          type: 'number'
+        }
+      }
+    };
+
+    const result = schema.validate(config);
+
+    t.notOk(result.error);
+    t.end();
+  });
+
+  test( 'addendum_namespaces of type boolean should be acceptable', function(t) {
+    const config = {
+      addendum_namespaces: {
+        tariff_zone_ids: {
+          type: 'boolean'
+        }
+      }
+    };
+
+    const result = schema.validate(config);
+
+    t.notOk(result.error);
+    t.end();
+  });
+
+};
+
+module.exports.all = (tape, common) => {
+
+  function test(name, testFunction) {
+    return tape('configValidation: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};


### PR DESCRIPTION
:wave: 

## Problem statement:

We want to import custom data into pelias index in elasticsearch and want to be able to filter the query results based on those custom data fields like we are able to filter the results based on sources and layers for example.

One solution is to fork the pelias-schema and extend the index mapping with whatever fields we want. But then we need to fork and other pelias services and update them to be able to use those custom data fields. But we really want to be connected with the open source community instead of start maintaining the forks of pelias services ourself. So we implemented the solution by adding some configuration options that can support our use case and probably help others.

## Findings:

Pelias schema have the addendum field, where we are able to import whatever data we want. Which is fine but problem is that, firstly its not indexed:

```
    addendum: {
      path_match: 'addendum.*',
      match_mapping_type: 'string',
      mapping: {
        type: 'keyword',
        index: false,
        doc_values: false
      }
    }

```

and secondly we can only store JSON data strings into addendum fields if we create the data through `pelias-model`.

## Solution:

In order to filter the results based on addendum fields, we firstly need to make addendum field indexed and secondly we need to be able to store data in other possible searchable types like string or array and so on.

Following are the changes we have made in order implement the above mentioned solution.

### pelias-schema

First of all, we have added the configuration option `indexAddendumField` in the `pelias-schema` to optionally be able index the addendum fields. The default value is set to `false`, in order to keep it backwards compatible.

### pelias-config (This PR)

We have added the configuration option `addendum_namespaces` in the `pelias-config` with the default value of empty object. 

We can configure the names for the namespaces we want to filter the data on, and type of data those namespaces will hold. The `type` of data will be useful in sanitizing and validating the data for the configured namespaces while importing and querying.

The configuration will look like the following:

```
"addendum_namespaces": {
    "tariff_zone_ids": {
      "type": "array"
    },
    "tariff_zone_authority": {
      "type": "string"
    }
  }
```

We have added the configuration validation and the Joi schema in `pelias-config` to make sure that the configuration is correct.

We have restricted the configurable types to only string, number, boolean and array. Because the addendum namespaces in the elasticsearch mapping is configured to be `keyword` type, which cannot store objects.

### pelias-model

We have updated the `setAddendum` function in `Document.js` to validate the configured `addendum_namespaces` as configured type, and not always as `object` type, as it was setup before this PR.

In addition to that all the configured addendum_namespaces will be stored in its configured data type.

All those namespaces which are not configured as `addendum_namespaces` will be validated as object and stored as json string, as it was before this changes. Which basically means that, if we don’t configured `addendum_namespaces` at all, we will not be affected by any change in this PR. So we have preserved the backwards compatibility.

We have also added new unit tests for `setAddendum` function, to test the new case cases.

### pelias-api

The goal her is to be able to filter the results based on configured `addendum_namespaces` directly in the URL, without the need to explicitly say that its addendum namespace.

**For example:**

If we have configured the following in the `pelias.json` 

```
"addendum_namespaces": {
    "tariff_zone_ids": {
      "type": "array"
    },
  }
```

then we will be able to filter the results based on the configured namespace, as follows

```
http://localhost:3100/v1/autocomplete?text=Langholen&tariff_zone_ids=INN:FareZone:94,INN:FareZone:78
```

Or if we have multiple `addendum_namespaces` configured like following

```
"addendum_namespaces": {
    "tariff_zone_ids": {
      "type": "array"
    },
      "public_id": {
       "type": "number"
    }
}
```

then we will be able to filter the results based on the multiple configured namespaces, as follows

```
http://localhost:3100/v1/search?text=Langholen&tariff_zone_ids=INN:FareZone:94,INN:FareZone:78&public_id=123
```

Following are the changes we have made in the pelias-api:

**Sanitization**
In the `pelias-api`, we have updated the `sanitizeAll.js` to find the configured `addendum_namespaces` in the received parameters and qualify them as a `goodParameters`.

We have added the new `_addendum.js` sanitizer, which will sanitize values provided for those configured `goodarameters` based on the configured types.

We have updated the sanitizers `autocomplete`, `search`, `reverse`, `structured_geocoding` and `nearby` to use the new `_addendum` sanitizer.

Added the unit test to test for the changes.

**Query**
We have added the new query filter `addendum_namespace_filter.js`, which creates the `filter` query for based on the configured types on `addendum_namespaces`

We have updated the quires `autocomplete`, `search`, `reverse` and `structured_geocoding` to use the new `addendum_namespace_filter`

**Search result**
We have updated the `geojsonify.js` to include the configured `addendum_namespaces` in the response as separate entity not under the addendum field. All non-configured addendum namespaces will be returned as the children of addendum in the result, as it was prior to this PR.

For example: For the following configuration

```
"addendum_namespaces": {
    "tariff_zone_ids": {
      "type": "array"
    },
    "tariff_zone_authorities": {
      "type": "array"
    },
    "public_id": {
      "type": 'string'
    },
  }
```

and the following request

```
http://localhost:3100/v1/autocomplete?text=Langholen&tariff_zone_ids=INN:FareZone:94,INN:FareZone:78&public_id=123&tariff_zone_authorities=TAR
```

`pelias-api` will add the following filters in the ES query:

```
'filter': [
  {
    'terms': {
      'addendum.tariff_zone_ids': [
        'TAR-123', 'TAR-345'
      ]
    }
  },
  {
    'terms': {
      'addendum.tariff_zone_authorities': [
        'TAR'
      ]
    }
  },
  {
    'term': {
      'addendum.public_id': '12345'
    }
  }
]
```
Note that its `terms` for array types and `term` for the string type addendum_namespaces.
