### PR TITLE
Remove unused `typeName` which was deprecated in es7, forbidden in es8

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -70,8 +70,7 @@
     }
   },
   "schema": {
-    "indexName": "pelias",
-    "typeName": "_doc"
+    "indexName": "pelias"
   },
   "logger": {
     "level": "debug",

--- a/test/expected-deep.json
+++ b/test/expected-deep.json
@@ -75,8 +75,7 @@
     }
   },
   "schema": {
-    "indexName": "pelias",
-    "typeName": "_doc"
+    "indexName": "pelias"
   },
   "logger": {
     "level": "debug",


### PR DESCRIPTION
---
#### Here's the reason for this change :rocket:

I'd like Pelias to run on elasticsearch 8 some day. This is a step towards that.

[Pelias does not support es6](https://github.com/pelias/documentation/blob/master/requirements.md#elasticsearch). Mapping types were first deprecated in es6 and optional with es7, but are now breaking with my es8 tests. 

---
#### Here's what actually got changed :clap:

I removed `typeName` from the default config.

In es6 it was recommended to be "_doc".
In es7 it was optional, but if specified it was required to be "_doc".
In es8 it's not allowed at all.

See more:
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html

---
#### Here's how others can test the changes :eyes:

I [ran the existing tests](https://github.com/michaelkirk-pelias/config/actions/runs/5513525025) and have successfully utilized this in the context of https://github.com/pelias/schema/pull/490