### PR TITLE
upgrade joi and version up node engine

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const default_config = require( __dirname + '/config/defaults.json' );
 let localpath = process.env.HOME + '/pelias.json'; // default location of pelias.json

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "url": "https://github.com/pelias/config/issues"
   },
   "engines": {
-    "node": ">=10.0.0",
+    "node": ">=14.0.0",
     "npm": ">=1.4.3",
     "elasticsearch": ">=1.1.1"
   },
   "dependencies": {
-    "@hapi/joi": "^16.0.0",
+    "joi": "^17.13.3",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/test/generate.js
+++ b/test/generate.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const config = require('../');
 const defaults = require('../config/defaults');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 module.exports.generate = {};
 


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

- To remove deprecation warning during the package install by replacing deprecated `@hapi/joi` with a direct replacement of it;`joi` 

---
#### Here's what actually got changed :clap:
- [x] Replace `@hapi/joi` with a direct replacement of it;`joi` 
- [x] Node engine version up to >=14 to match with the minimum version support of `joi`


---
#### Here's how others can test the changes :eyes:

It's a direct replacement. No further tests required.

### Reference
 [1] https://joi.dev/resources/status/
 [2] https://www.npmjs.com/package/joi?v=17.13.3
